### PR TITLE
use canonical bash for pre-commit script

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,8 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-for FILE in $(git diff --cached --name-only)
-  do
-  if [[ $FILE == *.cpp ]]  || [[ $FILE == *.h ]]
-    then clang-format -style=file -i $FILE
-  fi
-done
+while read -r FILE; do
+    if [[ $FILE =~ ('.cpp')|('.h')$ ]]; then
+        clang-format -style=file -i "$FILE"
+    fi
+done < <(git diff --cached --name-only)


### PR DESCRIPTION
hi !

this PR implements the following changes :
* use env for better portability accross platforms
* quote variables to avoid breaking on spaces, tabs & globs
* read line by line to avoid breaking on spaces, tabs & globs
* simpler test